### PR TITLE
Fix ban-duplicated-classes failures

### DIFF
--- a/jbpm-seldon-prediction-service/pom.xml
+++ b/jbpm-seldon-prediction-service/pom.xml
@@ -37,6 +37,29 @@
                                 <fail>true</fail>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>ban-duplicated-classes</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <banDuplicateClasses>
+                                        <dependencies>
+                                            <dependency>
+                                                <groupId>com.github.tomakehurst</groupId>
+                                                <artifactId>wiremock-jre8-standalone</artifactId>
+                                                <ignoreClasses>
+                                                    <ignoreClass>org.slf4j.*</ignoreClass>
+                                                </ignoreClasses>
+                                            </dependency>
+                                        </dependencies>
+                                    </banDuplicateClasses>
+                                </rules>
+                                <fail>true</fail>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
             </plugins>
@@ -107,6 +130,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                   <groupId>javax.activation</groupId>
+                   <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -138,6 +167,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
+            <exclusions>
+                <exclusion>
+                   <groupId>commons-logging</groupId>
+                   <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -162,10 +197,22 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
+            <exclusions>
+                <exclusion>
+                   <groupId>commons-logging</groupId>
+                   <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
+            <exclusions>
+                <exclusion>
+                   <groupId>commons-logging</groupId>
+                   <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
hi @ruivieira 
some exclusions are needed in the pom to avoid ban-duplicated-classes failures from the maven-enforcer-plugin.
Notice that wiremock-standalone is a shade-jar containing slf4j classes, and no exclusion is possible, so it's ignored with a rule to skip the failure.